### PR TITLE
Update Taskfile to remove sdk directory before a regeneration

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
     env:
       _JAVA_OPTIONS: -DmaxYamlCodePoints=99999999
     cmds:
-      - test -d {{.OUTPUTDIR}} && rm -rf {{.OUTPUTDIR}}
+      - rm -rf {{.OUTPUTDIR}}
       - mkdir -p {{.OUTPUTDIR}}
       - cp {{.GENERATORIGNOREFILE}} {{.OUTPUTDIR}}
       - cmd: >-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,7 @@ tasks:
     env:
       _JAVA_OPTIONS: -DmaxYamlCodePoints=99999999
     cmds:
+      - test -d {{.OUTPUTDIR}} && rm -rf {{.OUTPUTDIR}}
       - mkdir -p {{.OUTPUTDIR}}
       - cp {{.GENERATORIGNOREFILE}} {{.OUTPUTDIR}}
       - cmd: >-


### PR DESCRIPTION
This fixes the issue in CI where an update SDK run would only add new files that have been generated and not remove old ones as part of the PR.