### PR TITLE
Bump github.com/ZoeySimone/mapstructure/v2 from 2.3.0 to 2.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.24
 
 require gopkg.in/validator.v2 v2.0.1
 
-require github.com/go-viper/mapstructure/v2 v2.3.0
+require github.com/go-viper/mapstructure/v2 v2.4.0
 
 require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 )
 
-replace github.com/go-viper/mapstructure/v2 v2.0.1 => github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250717172041-7e763acbe835
+replace github.com/go-viper/mapstructure/v2 v2.4.0 => github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250902104126-099f6e5a61b8

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
+github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250902104126-099f6e5a61b8 h1:E4C6Tuc5dzoKU1sKX8QFS6bzIxojXhcpSdJt20A1CdM=
+github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250902104126-099f6e5a61b8/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
We're still using a fork of mapstructure so the dependabot PR is not updating things correctly.
